### PR TITLE
Add interactive menu for cyrah command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,15 @@ This CLI agent now supports a wide range of functionalities, including:
    node dist/index.js
    ```
 
-After installation you can also launch the UI directly via the bundled command:
+After installation you can also launch **Cyrah**, an interactive menu that lets
+you start the interpreter in different modes:
 
 ```bash
 npx cyrah
 ```
+
+Choose **Launch UI** to open the browser interface or **Start CLI Interpreter**
+to run completely in the terminal.
 
 ## Configuration via Environment Variables
 

--- a/dist/bin/cyrah.js
+++ b/dist/bin/cyrah.js
@@ -1,8 +1,41 @@
 #!/usr/bin/env node
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import dotenv from 'dotenv';
+import readline from 'readline';
 import { executeLaunchUITool } from '../tools/SystemIntegrationTool.js';
+import { main } from '../main.js';
 dotenv.config();
-const uiName = process.env.UI_NAME || 'cyrah';
-executeLaunchUITool({ uiName }).then(msg => {
-    console.log(msg);
+function showMenu() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        console.log('Cyrah Menu');
+        console.log('1) Launch UI');
+        console.log('2) Start CLI Interpreter');
+        console.log('3) Exit');
+        return new Promise((resolve) => {
+            rl.question('Choose an option: ', (answer) => __awaiter(this, void 0, void 0, function* () {
+                rl.close();
+                const choice = answer.trim();
+                if (choice === '1') {
+                    const msg = yield executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
+                    console.log(msg);
+                }
+                else if (choice === '2') {
+                    yield main();
+                }
+                resolve();
+            }));
+        });
+    });
+}
+showMenu().catch(err => {
+    console.error(`Error: ${err.message}`);
 });

--- a/src/bin/cyrah.ts
+++ b/src/bin/cyrah.ts
@@ -1,9 +1,34 @@
 #!/usr/bin/env node
 import dotenv from 'dotenv';
+import readline from 'readline';
 import { executeLaunchUITool } from '../tools/SystemIntegrationTool.js';
+import { main } from '../main.js';
 
 dotenv.config();
-const uiName = process.env.UI_NAME || 'cyrah';
-executeLaunchUITool({ uiName }).then(msg => {
-  console.log(msg);
+
+async function showMenu(): Promise<void> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  console.log('Cyrah Menu');
+  console.log('1) Launch UI');
+  console.log('2) Start CLI Interpreter');
+  console.log('3) Exit');
+
+  return new Promise((resolve) => {
+    rl.question('Choose an option: ', async (answer) => {
+      rl.close();
+      const choice = answer.trim();
+      if (choice === '1') {
+        const msg = await executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
+        console.log(msg);
+      } else if (choice === '2') {
+        await main();
+      }
+      resolve();
+    });
+  });
+}
+
+showMenu().catch(err => {
+  console.error(`Error: ${err.message}`);
 });


### PR DESCRIPTION
## Summary
- update docs with menu usage instructions
- add interactive menu for the `cyrah` command
- compile updated CLI script

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875bd1307648323a82be50d0a53cbec