### PR TITLE
Use node-pty in virtual terminal tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This CLI agent now supports a wide range of functionalities, including:
 *   **Advanced File Analysis:** Tools like `deepSearch` (with optional depth limits), directory structure listing, and detection of file content types.
 *   **System Management Tools:** Retrieve hardware details and manage network interfaces across platforms.
 *   **Image Generation Tool:** Use the `generateImage` tool to create images from text prompts. When `OPENAI_API_KEY` is configured, the tool generates real images using OpenAI; otherwise it falls back to a placeholder image.
-*   **Virtual Terminal Tool:** The `launchVirtualTerminal` tool now utilizes `node-pty` to provide a fully interactive shell session directly within the CLI.
+*   **Virtual Terminal Tool:** The `launchVirtualTerminal` tool uses `node-pty` to provide an interactive shell session when available and falls back to a regular shell spawn if pseudo-terminals are unsupported.
 *   **Conceptual GUI Integration:** Includes conceptual methods for display updates and input event handling, laying the groundwork for future graphical user interface implementations.
 
 ## Installation and Usage:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This CLI agent now supports a wide range of functionalities, including:
 
 *   **Extensible Tooling:** Easily integrate new tools and functionalities.
 *   **File Utilities:** Built-in helpers for reading, writing, and recursively searching files.
+*   **Advanced File Analysis:** Tools like `deepSearch` (with optional depth limits), directory structure listing, and detection of file content types.
 *   **System Management Tools:** Retrieve hardware details and manage network interfaces across platforms.
 *   **Image Generation Tool:** Use the `generateImage` tool to create images from text prompts. When `OPENAI_API_KEY` is configured, the tool generates real images using OpenAI; otherwise it falls back to a placeholder image.
 *   **Virtual Terminal Tool:** The `launchVirtualTerminal` tool now utilizes `node-pty` to provide a fully interactive shell session directly within the CLI.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This CLI agent now supports a wide range of functionalities, including:
 *   **Extensible Tooling:** Easily integrate new tools and functionalities.
 *   **File Utilities:** Built-in helpers for reading, writing, and recursively searching files.
 *   **System Management Tools:** Retrieve hardware details and manage network interfaces across platforms.
+*   **Image Generation Tool:** Use the `generateImage` tool to create images from text prompts. When `OPENAI_API_KEY` is configured, the tool generates real images using OpenAI; otherwise it falls back to a placeholder image.
+*   **Virtual Terminal Tool:** The `launchVirtualTerminal` tool now utilizes `node-pty` to provide a fully interactive shell session directly within the CLI.
 *   **Conceptual GUI Integration:** Includes conceptual methods for display updates and input event handling, laying the groundwork for future graphical user interface implementations.
 
 ## Installation and Usage:

--- a/dist/tools/ImageTool.js
+++ b/dist/tools/ImageTool.js
@@ -10,6 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 import Jimp from 'jimp';
 import * as path from 'path';
 import * as fs from 'fs';
+import OpenAI from 'openai';
 // Helper function to ensure output directory exists
 const ensureDirExists = (filePath) => {
     const dir = path.dirname(filePath);
@@ -189,7 +190,7 @@ export const generateImageTool = {
     type: "function",
     function: {
         name: "generateImage",
-        description: "Generates an image based on a text prompt using an external API. This tool requires configuration with a specific image generation service (e.g., DALL-E, Stable Diffusion) and a valid API key. Without proper configuration, it will only provide a conceptual response.",
+        description: "Generates an image based on a text prompt. If an OpenAI API key is configured, it will use the OpenAI image generation endpoint. Otherwise it falls back to generating a placeholder image with the prompt text.",
         parameters: {
             type: "object",
             properties: {
@@ -208,6 +209,33 @@ export const generateImageTool = {
 };
 export function executeGenerateImageTool(args) {
     return __awaiter(this, void 0, void 0, function* () {
+        var _a, _b;
+        if (process.env.OPENAI_API_KEY) {
+            const openai = new OpenAI({
+                apiKey: process.env.OPENAI_API_KEY,
+                baseURL: process.env.OPENAI_BASE_URL,
+            });
+            try {
+                const response = yield openai.images.generate({
+                    prompt: args.prompt,
+                    n: 1,
+                    size: '512x512',
+                    response_format: 'b64_json',
+                });
+                const imageData = (_b = (_a = response.data) === null || _a === void 0 ? void 0 : _a[0]) === null || _b === void 0 ? void 0 : _b.b64_json;
+                if (!imageData) {
+                    throw new Error('No image data returned');
+                }
+                const buffer = Buffer.from(imageData, 'base64');
+                ensureDirExists(args.outputPath);
+                fs.writeFileSync(args.outputPath, buffer);
+                return `Image generated using OpenAI and saved to ${args.outputPath}`;
+            }
+            catch (error) {
+                return `Error generating image via OpenAI: ${error.message}`;
+            }
+        }
+        // Fallback to placeholder image if no API key is configured
         try {
             const image = yield new Jimp(512, 512, 0xffffffff);
             const font = yield Jimp.loadFont(Jimp.FONT_SANS_32_BLACK);
@@ -218,10 +246,10 @@ export function executeGenerateImageTool(args) {
             }, 492, 492);
             ensureDirExists(args.outputPath);
             yield image.writeAsync(args.outputPath);
-            return `Image generated for prompt: "${args.prompt}" and saved to ${args.outputPath}`;
+            return `Placeholder image created for prompt "${args.prompt}" and saved to ${args.outputPath}`;
         }
         catch (error) {
-            return `Error generating image: ${error.message}`;
+            return `Error generating placeholder image: ${error.message}`;
         }
     });
 }

--- a/dist/tools/SystemIntegrationTool.js
+++ b/dist/tools/SystemIntegrationTool.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { exec } from "child_process";
+import { exec, spawn } from "child_process";
 import pty from "node-pty";
 import os from "os";
 export const launchUITool = {
@@ -79,27 +79,41 @@ export function executeLaunchVirtualTerminalTool(args) {
     return __awaiter(this, void 0, void 0, function* () {
         var _a, _b;
         const shell = os.platform() === 'win32' ? 'cmd.exe' : process.env.SHELL || 'bash';
-        const ptyProcess = pty.spawn(shell, [], {
-            name: args.terminalName,
-            cols: process.stdout.columns || 80,
-            rows: process.stdout.rows || 24,
-            cwd: process.cwd(),
-            env: process.env,
-        });
-        ptyProcess.onData(data => process.stdout.write(data));
-        (_b = (_a = process.stdin).setRawMode) === null || _b === void 0 ? void 0 : _b.call(_a, true);
-        const inputListener = (data) => ptyProcess.write(data.toString());
-        process.stdin.on('data', inputListener);
-        if (args.initialCommand) {
-            ptyProcess.write(args.initialCommand + '\n');
-        }
-        return new Promise(resolve => {
-            ptyProcess.onExit(() => {
-                var _a, _b;
-                (_b = (_a = process.stdin).setRawMode) === null || _b === void 0 ? void 0 : _b.call(_a, false);
-                process.stdin.off('data', inputListener);
-                resolve(`Virtual terminal "${args.terminalName}" session ended.`);
+        try {
+            const ptyProcess = pty.spawn(shell, [], {
+                name: args.terminalName,
+                cols: process.stdout.columns || 80,
+                rows: process.stdout.rows || 24,
+                cwd: process.cwd(),
+                env: process.env,
             });
-        });
+            ptyProcess.onData(data => process.stdout.write(data));
+            (_b = (_a = process.stdin).setRawMode) === null || _b === void 0 ? void 0 : _b.call(_a, true);
+            const inputListener = (data) => ptyProcess.write(data.toString());
+            process.stdin.on('data', inputListener);
+            if (args.initialCommand) {
+                ptyProcess.write(args.initialCommand + '\n');
+            }
+            return new Promise(resolve => {
+                ptyProcess.onExit(() => {
+                    var _a, _b;
+                    (_b = (_a = process.stdin).setRawMode) === null || _b === void 0 ? void 0 : _b.call(_a, false);
+                    process.stdin.off('data', inputListener);
+                    resolve(`Virtual terminal "${args.terminalName}" session ended.`);
+                });
+            });
+        }
+        catch (error) {
+            // Fallback to a plain shell if node-pty fails
+            return new Promise(resolve => {
+                const child = spawn(shell, { stdio: 'inherit' });
+                if (args.initialCommand && child.stdin) {
+                    child.stdin.write(args.initialCommand + '\n');
+                }
+                child.on('exit', () => {
+                    resolve(`Terminal "${args.terminalName}" session ended.`);
+                });
+            });
+        }
     });
 }

--- a/dist/tools/SystemIntegrationTool.js
+++ b/dist/tools/SystemIntegrationTool.js
@@ -7,7 +7,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { exec, spawn } from "child_process";
+import { exec } from "child_process";
+import pty from "node-pty";
 import os from "os";
 export const launchUITool = {
     type: "function",
@@ -76,11 +77,29 @@ export const launchVirtualTerminalTool = {
 };
 export function executeLaunchVirtualTerminalTool(args) {
     return __awaiter(this, void 0, void 0, function* () {
+        var _a, _b;
         const shell = os.platform() === 'win32' ? 'cmd.exe' : process.env.SHELL || 'bash';
-        const child = spawn(shell, [], { stdio: 'inherit' });
-        if (args.initialCommand && child.stdin) {
-            child.stdin.write(args.initialCommand + '\n');
+        const ptyProcess = pty.spawn(shell, [], {
+            name: args.terminalName,
+            cols: process.stdout.columns || 80,
+            rows: process.stdout.rows || 24,
+            cwd: process.cwd(),
+            env: process.env,
+        });
+        ptyProcess.onData(data => process.stdout.write(data));
+        (_b = (_a = process.stdin).setRawMode) === null || _b === void 0 ? void 0 : _b.call(_a, true);
+        const inputListener = (data) => ptyProcess.write(data.toString());
+        process.stdin.on('data', inputListener);
+        if (args.initialCommand) {
+            ptyProcess.write(args.initialCommand + '\n');
         }
-        return `Launched virtual terminal "${args.terminalName}" using ${shell}. Type 'exit' to close.`;
+        return new Promise(resolve => {
+            ptyProcess.onExit(() => {
+                var _a, _b;
+                (_b = (_a = process.stdin).setRawMode) === null || _b === void 0 ? void 0 : _b.call(_a, false);
+                process.stdin.off('data', inputListener);
+                resolve(`Virtual terminal "${args.terminalName}" session ended.`);
+            });
+        });
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "litellm": "^0.12.0",
         "minecraft-protocol": "^1.58.0",
         "minimist": "^1.2.8",
+        "node-pty": "^0.10.1",
+        "openai": "^4.11.1",
         "pino": "^9.3.2",
         "pino-pretty": "^11.2.2",
         "prettier": "^3.2.5",
@@ -5316,6 +5318,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/nan": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "license": "MIT"
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.0.tgz",
@@ -5404,6 +5412,16 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.10.1.tgz",
+      "integrity": "sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.14.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "rcon-client": "^4.2.5",
     "sql.js": "^1.13.0",
     "xml2js": "^0.6.2",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "openai": "^4.11.1",
+    "node-pty": "^0.10.1"
   }
 }

--- a/src/tools/ImageTool.ts
+++ b/src/tools/ImageTool.ts
@@ -3,6 +3,7 @@ import { Tool } from "../core/types.js";
 import Jimp from 'jimp';
 import * as path from 'path';
 import * as fs from 'fs';
+import OpenAI from 'openai';
 
 // Helper function to ensure output directory exists
 const ensureDirExists = (filePath: string) => {
@@ -180,7 +181,7 @@ export const generateImageTool: Tool = {
   type: "function",
   function: {
     name: "generateImage",
-    description: "Generates an image based on a text prompt using an external API. This tool requires configuration with a specific image generation service (e.g., DALL-E, Stable Diffusion) and a valid API key. Without proper configuration, it will only provide a conceptual response.",
+    description: "Generates an image based on a text prompt. If an OpenAI API key is configured, it will use the OpenAI image generation endpoint. Otherwise it falls back to generating a placeholder image with the prompt text.",
     parameters: {
       type: "object",
       properties: {
@@ -199,6 +200,32 @@ export const generateImageTool: Tool = {
 };
 
 export async function executeGenerateImageTool(args: { prompt: string; outputPath: string }): Promise<string> {
+  if (process.env.OPENAI_API_KEY) {
+    const openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      baseURL: process.env.OPENAI_BASE_URL,
+    });
+    try {
+      const response = await openai.images.generate({
+        prompt: args.prompt,
+        n: 1,
+        size: '512x512',
+        response_format: 'b64_json',
+      });
+      const imageData = response.data?.[0]?.b64_json;
+      if (!imageData) {
+        throw new Error('No image data returned');
+      }
+      const buffer = Buffer.from(imageData, 'base64');
+      ensureDirExists(args.outputPath);
+      fs.writeFileSync(args.outputPath, buffer);
+      return `Image generated using OpenAI and saved to ${args.outputPath}`;
+    } catch (error: any) {
+      return `Error generating image via OpenAI: ${error.message}`;
+    }
+  }
+
+  // Fallback to placeholder image if no API key is configured
   try {
     const image = await new Jimp(512, 512, 0xffffffff);
     const font = await Jimp.loadFont(Jimp.FONT_SANS_32_BLACK);
@@ -216,8 +243,8 @@ export async function executeGenerateImageTool(args: { prompt: string; outputPat
     );
     ensureDirExists(args.outputPath);
     await image.writeAsync(args.outputPath);
-    return `Image generated for prompt: "${args.prompt}" and saved to ${args.outputPath}`;
+    return `Placeholder image created for prompt "${args.prompt}" and saved to ${args.outputPath}`;
   } catch (error: any) {
-    return `Error generating image: ${error.message}`;
+    return `Error generating placeholder image: ${error.message}`;
   }
 }

--- a/src/tools/SystemIntegrationTool.ts
+++ b/src/tools/SystemIntegrationTool.ts
@@ -1,6 +1,7 @@
 
 import { Tool } from "../core/types.js";
-import { exec, spawn } from "child_process";
+import { exec } from "child_process";
+import pty from "node-pty";
 import os from "os";
 
 export const launchUITool: Tool = {
@@ -71,9 +72,29 @@ export const launchVirtualTerminalTool: Tool = {
 
 export async function executeLaunchVirtualTerminalTool(args: { terminalName: string; initialCommand?: string }): Promise<string> {
   const shell = os.platform() === 'win32' ? 'cmd.exe' : process.env.SHELL || 'bash';
-  const child = spawn(shell, [], { stdio: 'inherit' });
-  if (args.initialCommand && child.stdin) {
-    child.stdin.write(args.initialCommand + '\n');
+  const ptyProcess = pty.spawn(shell, [], {
+    name: args.terminalName,
+    cols: process.stdout.columns || 80,
+    rows: process.stdout.rows || 24,
+    cwd: process.cwd(),
+    env: process.env as any,
+  });
+
+  ptyProcess.onData(data => process.stdout.write(data));
+
+  process.stdin.setRawMode?.(true);
+  const inputListener = (data: Buffer) => ptyProcess.write(data.toString());
+  process.stdin.on('data', inputListener);
+
+  if (args.initialCommand) {
+    ptyProcess.write(args.initialCommand + '\n');
   }
-  return `Launched virtual terminal "${args.terminalName}" using ${shell}. Type 'exit' to close.`;
+
+  return new Promise(resolve => {
+    ptyProcess.onExit(() => {
+      process.stdin.setRawMode?.(false);
+      process.stdin.off('data', inputListener);
+      resolve(`Virtual terminal "${args.terminalName}" session ended.`);
+    });
+  });
 }

--- a/src/tools/SystemIntegrationTool.ts
+++ b/src/tools/SystemIntegrationTool.ts
@@ -1,6 +1,6 @@
 
 import { Tool } from "../core/types.js";
-import { exec } from "child_process";
+import { exec, spawn } from "child_process";
 import pty from "node-pty";
 import os from "os";
 
@@ -72,29 +72,42 @@ export const launchVirtualTerminalTool: Tool = {
 
 export async function executeLaunchVirtualTerminalTool(args: { terminalName: string; initialCommand?: string }): Promise<string> {
   const shell = os.platform() === 'win32' ? 'cmd.exe' : process.env.SHELL || 'bash';
-  const ptyProcess = pty.spawn(shell, [], {
-    name: args.terminalName,
-    cols: process.stdout.columns || 80,
-    rows: process.stdout.rows || 24,
-    cwd: process.cwd(),
-    env: process.env as any,
-  });
-
-  ptyProcess.onData(data => process.stdout.write(data));
-
-  process.stdin.setRawMode?.(true);
-  const inputListener = (data: Buffer) => ptyProcess.write(data.toString());
-  process.stdin.on('data', inputListener);
-
-  if (args.initialCommand) {
-    ptyProcess.write(args.initialCommand + '\n');
-  }
-
-  return new Promise(resolve => {
-    ptyProcess.onExit(() => {
-      process.stdin.setRawMode?.(false);
-      process.stdin.off('data', inputListener);
-      resolve(`Virtual terminal "${args.terminalName}" session ended.`);
+  try {
+    const ptyProcess = pty.spawn(shell, [], {
+      name: args.terminalName,
+      cols: process.stdout.columns || 80,
+      rows: process.stdout.rows || 24,
+      cwd: process.cwd(),
+      env: process.env as any,
     });
-  });
+
+    ptyProcess.onData(data => process.stdout.write(data));
+
+    process.stdin.setRawMode?.(true);
+    const inputListener = (data: Buffer) => ptyProcess.write(data.toString());
+    process.stdin.on('data', inputListener);
+
+    if (args.initialCommand) {
+      ptyProcess.write(args.initialCommand + '\n');
+    }
+
+    return new Promise(resolve => {
+      ptyProcess.onExit(() => {
+        process.stdin.setRawMode?.(false);
+        process.stdin.off('data', inputListener);
+        resolve(`Virtual terminal "${args.terminalName}" session ended.`);
+      });
+    });
+  } catch (error: any) {
+    // Fallback to a plain shell if node-pty fails
+    return new Promise(resolve => {
+      const child = spawn(shell, { stdio: 'inherit' });
+      if (args.initialCommand && child.stdin) {
+        child.stdin.write(args.initialCommand + '\n');
+      }
+      child.on('exit', () => {
+        resolve(`Terminal "${args.terminalName}" session ended.`);
+      });
+    });
+  }
 }

--- a/tests/tools/ImageTool.test.ts
+++ b/tests/tools/ImageTool.test.ts
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+import { executeGenerateImageTool } from '@/tools/ImageTool';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    images: {
+      generate: jest
+        .fn()
+        .mockResolvedValue({ data: [{ b64_json: Buffer.from('mock').toString('base64') }] }),
+    },
+  })),
+}));
+
+describe('ImageTool', () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const tmpDir = path.join(__dirname, 'tmp_images');
+  const outputPath = path.join(tmpDir, 'output.png');
+
+  beforeAll(() => {
+    if (!fs.existsSync(tmpDir)) {
+      fs.mkdirSync(tmpDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(outputPath)) {
+      fs.unlinkSync(outputPath);
+    }
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_BASE_URL;
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('generates a placeholder image when no OPENAI_API_KEY is set', async () => {
+    delete process.env.OPENAI_API_KEY;
+    const result = await executeGenerateImageTool({ prompt: 'hello', outputPath });
+    expect(result).toContain('Placeholder image created');
+    expect(fs.existsSync(outputPath)).toBe(true);
+  });
+
+  it('generates an image via OpenAI when OPENAI_API_KEY is set', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    const result = await executeGenerateImageTool({ prompt: 'hi', outputPath });
+    expect(result).toContain('OpenAI');
+  });
+});

--- a/tests/tools/SystemIntegrationTool.test.ts
+++ b/tests/tools/SystemIntegrationTool.test.ts
@@ -4,7 +4,16 @@ import { exec } from 'child_process';
 
 jest.mock('child_process', () => ({
   exec: jest.fn((cmd: string, cb: (err: any) => void) => cb(null)),
-  spawn: jest.fn(),
+  spawn: jest.fn(() => {
+    const listeners: Record<string, () => void> = {};
+    return {
+      stdin: { write: jest.fn() },
+      on: jest.fn((event: string, cb: () => void) => {
+        listeners[event] = cb;
+        if (event === 'exit') process.nextTick(cb);
+      }),
+    } as any;
+  }),
 }));
 
 describe('SystemIntegrationTool', () => {
@@ -13,5 +22,18 @@ describe('SystemIntegrationTool', () => {
     const msg = await executeLaunchUITool({ uiName: 'cyrah' });
     expect(msg).toContain('http://example.com/cyrah');
     delete process.env.UI_BASE_URL;
+  });
+
+  it('falls back to spawn when node-pty fails', async () => {
+    jest.isolateModules(async () => {
+      jest.doMock('node-pty', () => ({
+        __esModule: true,
+        default: { spawn: jest.fn(() => { throw new Error('pty failed'); }) },
+      }));
+      const { executeLaunchVirtualTerminalTool } = await import('@/tools/SystemIntegrationTool');
+      const result = await executeLaunchVirtualTerminalTool({ terminalName: 'test' });
+      expect(result).toContain('session ended');
+    });
+    jest.dontMock('node-pty');
   });
 });


### PR DESCRIPTION
## Summary
- add `node-pty` dependency
- implement `launchVirtualTerminal` using node-pty for a real interactive shell
- document the new virtual terminal functionality in the README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687648044d248323b721f1fe1578586b