### PR TITLE
Fix path imports for runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ You can also launch a simple web interface:
 ```bash
 npm run start-web
 ```
-Then open http://localhost:3000 in your browser to chat.
+Then open http://localhost:3000 in your browser to chat. The interactive menu
+now includes an option to start this server as well.
 
 This command now starts the CLI interpreter immediately. If you prefer the
 previous interactive menu, run `npx cyrah --menu`.

--- a/README.md
+++ b/README.md
@@ -84,15 +84,25 @@ This CLI agent now supports a wide range of functionalities, including:
    node dist/index.js
    ```
 
-After installation you can also launch **Cyrah**, an interactive menu that lets
-you start the interpreter in different modes:
+After installation you can launch **Cyrah** directly from the terminal:
 
 ```bash
 npx cyrah
 ```
 
-Choose **Launch UI** to open the browser interface or **Start CLI Interpreter**
-to run completely in the terminal.
+You can also launch a simple web interface:
+```bash
+npm run start-web
+```
+Then open http://localhost:3000 in your browser to chat.
+
+This command now starts the CLI interpreter immediately. If you prefer the
+previous interactive menu, run `npx cyrah --menu`.
+
+You can pass interpreter options directly on the command line or via
+environment variables. Use `--env KEY=VALUE` to set an environment variable for
+the current run, or choose **Set Environment Variables** in the interactive
+menu to enter them interactively. A `--help` flag shows the available options.
 
 ## Configuration via Environment Variables
 
@@ -126,4 +136,5 @@ The interpreter reads various settings from environment variables if correspondi
   `DISPLAY_MODE` is set to `gui`.
 - `DISPLAY_MODE` – Set to `gui` to automatically open the UI when the interpreter starts.
 
-Create a `.env` file with these values to avoid passing them as flags.
+Create a `.env` file with these values to avoid passing them as flags. You can
+also provide temporary overrides on the command line using `--env KEY=VALUE`.

--- a/README.md
+++ b/README.md
@@ -95,10 +95,12 @@ You can also launch a simple web interface:
 npm run start-web
 ```
 Then open http://localhost:3000 in your browser to chat. The interactive menu
-now includes an option to start this server as well.
+now includes an option to start this server as well, or you can launch it
+alongside the CLI with the `--web` flag.
 
 This command now starts the CLI interpreter immediately. If you prefer the
-previous interactive menu, run `npx cyrah --menu`.
+previous interactive menu, run `npx cyrah --menu`. Use `npx cyrah --web` to
+start the web interface alongside the CLI.
 
 You can pass interpreter options directly on the command line or via
 environment variables. Use `--env KEY=VALUE` to set an environment variable for

--- a/dist/bin/cyrah.js
+++ b/dist/bin/cyrah.js
@@ -61,14 +61,15 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         const argv = minimist(process.argv.slice(2), {
             string: ['env'],
-            boolean: ['menu', 'help'],
-            alias: { e: 'env', h: 'help' }
+            boolean: ['menu', 'help', 'web'],
+            alias: { e: 'env', h: 'help', w: 'web' }
         });
         if (argv.help) {
             console.log(`Usage: cyrah [options]
 
 Options:
   --menu, -m          Show interactive menu
+  --web,  -w          Start the web interface alongside the CLI
   --env,  -e KEY=VAL  Set environment variable (repeatable)
   --help, -h          Show this help message
 
@@ -87,6 +88,10 @@ Any other options are forwarded to the interpreter.`);
         if (argv.menu) {
             yield showMenu();
             return;
+        }
+        if (argv.web) {
+            yield import('../server.js');
+            console.log('Web interface started. Open http://localhost:3000 in your browser.');
         }
         yield main();
     });

--- a/dist/bin/cyrah.js
+++ b/dist/bin/cyrah.js
@@ -10,32 +10,82 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import dotenv from 'dotenv';
 import readline from 'readline';
+import minimist from 'minimist';
 import { executeLaunchUITool } from '../tools/SystemIntegrationTool.js';
 import { main } from '../main.js';
 dotenv.config();
 function showMenu() {
     return __awaiter(this, void 0, void 0, function* () {
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-        console.log('Cyrah Menu');
-        console.log('1) Launch UI');
-        console.log('2) Start CLI Interpreter');
-        console.log('3) Exit');
-        return new Promise((resolve) => {
-            rl.question('Choose an option: ', (answer) => __awaiter(this, void 0, void 0, function* () {
+        const ask = (query) => new Promise((res) => rl.question(query, res));
+        while (true) {
+            console.log('Cyrah Menu');
+            console.log('1) Launch UI');
+            console.log('2) Start CLI Interpreter');
+            console.log('3) Set Environment Variables');
+            console.log('4) Exit');
+            const choice = (yield ask('Choose an option: ')).trim();
+            if (choice === '1') {
+                const msg = yield executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
+                console.log(msg);
+            }
+            else if (choice === '2') {
                 rl.close();
-                const choice = answer.trim();
-                if (choice === '1') {
-                    const msg = yield executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
-                    console.log(msg);
+                yield main();
+                return;
+            }
+            else if (choice === '3') {
+                while (true) {
+                    const pair = (yield ask('Enter KEY=VALUE (blank to finish): ')).trim();
+                    if (!pair)
+                        break;
+                    const [key, ...rest] = pair.split('=');
+                    if (key && rest.length > 0) {
+                        process.env[key] = rest.join('=');
+                    }
                 }
-                else if (choice === '2') {
-                    yield main();
-                }
-                resolve();
-            }));
-        });
+            }
+            else if (choice === '4') {
+                rl.close();
+                return;
+            }
+        }
     });
 }
-showMenu().catch(err => {
+function run() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const argv = minimist(process.argv.slice(2), {
+            string: ['env'],
+            boolean: ['menu', 'help'],
+            alias: { e: 'env', h: 'help' }
+        });
+        if (argv.help) {
+            console.log(`Usage: cyrah [options]
+
+Options:
+  --menu, -m          Show interactive menu
+  --env,  -e KEY=VAL  Set environment variable (repeatable)
+  --help, -h          Show this help message
+
+Any other options are forwarded to the interpreter.`);
+            return;
+        }
+        if (argv.env) {
+            const envs = Array.isArray(argv.env) ? argv.env : [argv.env];
+            for (const pair of envs) {
+                const [key, ...rest] = pair.split('=');
+                if (key && rest.length > 0) {
+                    process.env[key] = rest.join('=');
+                }
+            }
+        }
+        if (argv.menu) {
+            yield showMenu();
+            return;
+        }
+        yield main();
+    });
+}
+run().catch(err => {
     console.error(`Error: ${err.message}`);
 });

--- a/dist/bin/cyrah.js
+++ b/dist/bin/cyrah.js
@@ -20,21 +20,26 @@ function showMenu() {
         const ask = (query) => new Promise((res) => rl.question(query, res));
         while (true) {
             console.log('Cyrah Menu');
-            console.log('1) Launch UI');
-            console.log('2) Start CLI Interpreter');
-            console.log('3) Set Environment Variables');
-            console.log('4) Exit');
+            console.log('1) Start Web Interface');
+            console.log('2) Launch UI');
+            console.log('3) Start CLI Interpreter');
+            console.log('4) Set Environment Variables');
+            console.log('5) Exit');
             const choice = (yield ask('Choose an option: ')).trim();
             if (choice === '1') {
+                yield import('../server.js');
+                console.log('Web interface started. Open http://localhost:3000 in your browser.');
+            }
+            else if (choice === '2') {
                 const msg = yield executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
                 console.log(msg);
             }
-            else if (choice === '2') {
+            else if (choice === '3') {
                 rl.close();
                 yield main();
                 return;
             }
-            else if (choice === '3') {
+            else if (choice === '4') {
                 while (true) {
                     const pair = (yield ask('Enter KEY=VALUE (blank to finish): ')).trim();
                     if (!pair)
@@ -45,7 +50,7 @@ function showMenu() {
                     }
                 }
             }
-            else if (choice === '4') {
+            else if (choice === '5') {
                 rl.close();
                 return;
             }

--- a/dist/server.js
+++ b/dist/server.js
@@ -1,0 +1,77 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+import express from 'express';
+import http from 'http';
+import { Server as SocketIOServer } from 'socket.io';
+import path from 'path';
+import dotenv from 'dotenv';
+import { Interpreter } from './core/Interpreter.js';
+import { config } from './config.js';
+dotenv.config();
+function createInterpreter() {
+    var _a;
+    const envBool = (value, fallback) => {
+        if (value === undefined)
+            return fallback;
+        return value.toLowerCase() === 'true';
+    };
+    const envNumber = (value, fallback) => {
+        if (value === undefined)
+            return fallback;
+        const num = parseFloat(value);
+        return isNaN(num) ? fallback : num;
+    };
+    const envString = (value, fallback) => {
+        return value !== undefined ? value : fallback;
+    };
+    const options = {
+        autoRun: envBool(process.env.AUTO_RUN, true),
+        loop: envBool(process.env.LOOP, config.defaultLoop),
+        offline: envBool(process.env.OFFLINE, false),
+        verbose: envBool(process.env.VERBOSE, false),
+        debug: envBool(process.env.DEBUG, false),
+        safeMode: process.env.SAFE_MODE || config.defaultSafeMode,
+        maxOutput: envNumber(process.env.MAX_OUTPUT, config.defaultMaxOutput),
+        llmProvider: process.env.LLM_PROVIDER,
+        llmModel: process.env.LLM_MODEL,
+        llmApiKey: process.env.LLM_API_KEY || (process.env.LLM_PROVIDER === 'ollama' ? process.env.OLLAMA_API_KEY : process.env.OPENAI_API_KEY),
+        llmBaseUrl: process.env.LLM_BASE_URL || (process.env.LLM_PROVIDER === 'openai' ? process.env.OPENAI_BASE_URL : process.env.OLLAMA_BASE_URL),
+        llmTemperature: envNumber(process.env.LLM_TEMPERATURE, 0),
+        llmMaxTokens: envNumber(process.env.LLM_MAX_TOKENS, config.defaultMaxOutput),
+        conversationHistoryPath: process.env.CONVERSATION_HISTORY_PATH,
+        conversationFilename: envString(process.env.CONVERSATION_FILENAME, config.conversationFilename),
+        conversationMaxLength: envNumber(process.env.CONVERSATION_MAX_LENGTH, undefined),
+        skillsPath: envString(process.env.SKILLS_PATH, undefined),
+        importSkills: envBool(process.env.IMPORT_SKILLS, false),
+        displayMode: ((_a = process.env.DISPLAY_MODE) !== null && _a !== void 0 ? _a : 'cli'),
+    };
+    return new Interpreter(options);
+}
+const interpreter = createInterpreter();
+const app = express();
+const server = http.createServer(app);
+const io = new SocketIOServer(server);
+app.use(express.json());
+app.use(express.static(path.join(__dirname, '../public')));
+io.on('connection', (socket) => {
+    socket.on('message', (msg) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            const messages = yield interpreter.chat(msg);
+            socket.emit('response', messages[messages.length - 1]);
+        }
+        catch (err) {
+            socket.emit('response', { role: 'error', content: err.message });
+        }
+    }));
+});
+const PORT = parseInt(process.env.PORT || '3000', 10);
+server.listen(PORT, () => {
+    console.log(`Web interface running at http://localhost:${PORT}`);
+});

--- a/dist/tools/AutomationTool.js
+++ b/dist/tools/AutomationTool.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import * as fs from "fs";
 import * as os from "os";
-import { executeShellCommand, commandExists, shellEscape } from "@utils/command.js";
+import { executeShellCommand, commandExists, shellEscape } from "../utils/command.js";
 export const createScriptFileTool = {
     type: "function",
     function: {

--- a/dist/tools/ClipboardTool.js
+++ b/dist/tools/ClipboardTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 const readClipboardToolDefinition = {
     type: "function",
     function: {

--- a/dist/tools/CloudTool.js
+++ b/dist/tools/CloudTool.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 export const listCloudResourcesTool = {
     type: "function",
     function: {

--- a/dist/tools/CompressionTool.js
+++ b/dist/tools/CompressionTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as fs from "fs";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const zipCompressTool = {
     type: "function",
     function: {

--- a/dist/tools/ContainerTool.js
+++ b/dist/tools/ContainerTool.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 function ensureDocker() {
     return __awaiter(this, void 0, void 0, function* () {
         if (yield commandExists("docker")) {

--- a/dist/tools/NetworkConfigTool.js
+++ b/dist/tools/NetworkConfigTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const getNetworkConfigTool = {
     type: "function",
     function: {

--- a/dist/tools/NetworkDiagnosticsTool.js
+++ b/dist/tools/NetworkDiagnosticsTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const checkNetworkConnectivityTool = {
     type: "function",
     function: {

--- a/dist/tools/PackageManagerTool.js
+++ b/dist/tools/PackageManagerTool.js
@@ -10,7 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 import * as os from "os";
 import * as path from "path"; // Added import
 import * as fs from "fs"; // Added import
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const npmInstallTool = {
     type: "function",
     function: {

--- a/dist/tools/ProcessManagementTool.js
+++ b/dist/tools/ProcessManagementTool.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import * as os from "os";
 import { spawn } from "child_process";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const terminateProcessTool = {
     type: "function",
     function: {

--- a/dist/tools/SDLCtool.js
+++ b/dist/tools/SDLCtool.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const createBranchTool = {
     type: "function",
     function: {

--- a/dist/tools/SchedulerTool.js
+++ b/dist/tools/SchedulerTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand, commandExists, shellEscape } from "@utils/command.js";
+import { executeShellCommand, commandExists, shellEscape } from "../utils/command.js";
 export const createScheduledTaskTool = {
     type: "function",
     function: {

--- a/dist/tools/SecurityTool.js
+++ b/dist/tools/SecurityTool.js
@@ -12,7 +12,7 @@ import * as fs from "fs";
 import { exec } from "child_process";
 import * as crypto from "crypto";
 import * as path from "path";
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 export const scanOpenPortsTool = {
     type: "function",
     function: {

--- a/dist/tools/ServiceManagementTool.js
+++ b/dist/tools/ServiceManagementTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const startServiceTool = {
     type: "function",
     function: {

--- a/dist/tools/SystemDiagnosticsTool.js
+++ b/dist/tools/SystemDiagnosticsTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const checkSystemHealthTool = {
     type: "function",
     function: {

--- a/dist/tools/SystemMonitorTool.js
+++ b/dist/tools/SystemMonitorTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const getDiskUsageTool = {
     type: "function",
     function: {

--- a/dist/tools/SystemPowerTool.js
+++ b/dist/tools/SystemPowerTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const rebootSystemTool = {
     type: "function",
     function: {

--- a/dist/tools/SystemTool.js
+++ b/dist/tools/SystemTool.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import * as os from "os";
 import { exec } from "child_process";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const systemInfoTool = {
     type: "function",
     function: {

--- a/dist/tools/UserManagementTool.js
+++ b/dist/tools/UserManagementTool.js
@@ -8,7 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const createUserTool = {
     type: "function",
     function: {

--- a/dist/tools/VirtualizationTool.js
+++ b/dist/tools/VirtualizationTool.js
@@ -7,7 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 export const listVirtualMachinesTool = {
     type: "function",
     function: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cheerio": "^1.1.0",
         "dotenv": "^16.4.5",
         "env-paths": "^3.0.0",
+        "express": "^5.1.0",
         "jimp": "^0.22.10",
         "js-yaml": "^4.1.0",
         "litellm": "^0.12.0",
@@ -26,6 +27,7 @@
         "pino-pretty": "^11.2.2",
         "prettier": "^3.2.5",
         "rcon-client": "^4.2.5",
+        "socket.io": "^4.8.1",
         "sql.js": "^1.13.0",
         "xml2js": "^0.6.2"
       },
@@ -36,11 +38,13 @@
         "@types/assert": "^1.5.11",
         "@types/dotenv": "^6.1.1",
         "@types/env-paths": "^1.0.2",
+        "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/minimist": "^1.2.5",
         "@types/node": "^22.16.3",
         "@types/pino": "^7.0.4",
+        "@types/socket.io": "^3.0.1",
         "@types/xml2js": "^0.4.14",
         "cross-env": "^7.0.3",
         "jest": "^30.0.4",
@@ -1681,6 +1685,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -1778,6 +1788,36 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/dotenv": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
@@ -1798,6 +1838,38 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/env-paths/-/env-paths-1.0.2.tgz",
       "integrity": "sha512-EVOU+P4CSugzatd2GD8tVEYYR/OMcwzkneaJLx0R091gTqW2wZO1vpiWoM+BKZAEYdzif0SfwRuBvegIZBcZnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
+      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
+      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1846,6 +1918,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
@@ -1890,6 +1969,20 @@
         "pino": "*"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/readable-stream": {
       "version": "4.0.21",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.21.tgz",
@@ -1897,6 +1990,39 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/socket.io": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-3.0.1.tgz",
+      "integrity": "sha512-XSma2FhVD78ymvoxYV4xGXrIH/0EKQ93rR+YR0Y+Kw1xbPzLDCip/UWSejZ08FpxYeYNci/PZPQS9anrvJRqMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "*"
       }
     },
     "node_modules/@types/sql.js": {
@@ -2255,6 +2381,40 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2558,11 +2718,40 @@
         }
       ]
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
       "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -2693,6 +2882,44 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2994,12 +3221,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -3136,6 +3415,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3242,6 +3530,20 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3257,6 +3559,12 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -3301,6 +3609,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -3327,6 +3644,95 @@
       "resolved": "https://registry.npmjs.org/endian-toggle/-/endian-toggle-0.0.0.tgz",
       "integrity": "sha512-ShfqhXeHRE4TmggSlHXG8CMGIcsOsqDw/GcoPcosToE59Rm9e4aXaMhEQf2kPBsBRrKem1bbOAv5gOKnkliMFQ==",
       "license": "MIT"
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -3361,6 +3767,36 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3370,6 +3806,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -3393,6 +3835,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/event-target-shim": {
@@ -3481,6 +3932,69 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fast-copy": {
@@ -3592,6 +4106,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3681,6 +4212,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3703,6 +4252,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3723,6 +4281,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3731,6 +4313,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3787,6 +4382,18 @@
         "process": "^0.11.10"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3802,6 +4409,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -3845,6 +4476,31 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/human-signals": {
@@ -3957,8 +4613,16 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4007,6 +4671,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -5130,6 +5800,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -5138,6 +5817,27 @@
         "charenc": "0.0.2",
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -5369,6 +6069,15 @@
         "url": "https://nearley.js.org/#give-to-nearley"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -5474,6 +6183,27 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/omggif": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
@@ -5486,6 +6216,18 @@
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -5734,6 +6476,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5787,6 +6538,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",
@@ -6137,6 +6897,19 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -6178,6 +6951,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -6200,6 +6988,30 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/rcon-client": {
@@ -6326,6 +7138,22 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6380,6 +7208,70 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6401,6 +7293,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6434,6 +7398,141 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/sonic-boom": {
@@ -6497,6 +7596,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string_decoder": {
@@ -6826,6 +7934,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
@@ -7002,6 +8119,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typed-emitter": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-0.1.0.tgz",
@@ -7035,6 +8187,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -7169,6 +8330,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/walker": {
@@ -7358,6 +8528,29 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xhr": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "start-web": "node dist/server.js"
   },
   "bin": {
     "cyrah": "./dist/bin/cyrah.js"
@@ -19,11 +20,13 @@
     "@types/assert": "^1.5.11",
     "@types/dotenv": "^6.1.1",
     "@types/env-paths": "^1.0.2",
+    "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/minimist": "^1.2.5",
     "@types/node": "^22.16.3",
     "@types/pino": "^7.0.4",
+    "@types/socket.io": "^3.0.1",
     "@types/xml2js": "^0.4.14",
     "cross-env": "^7.0.3",
     "jest": "^30.0.4",
@@ -38,18 +41,20 @@
     "cheerio": "^1.1.0",
     "dotenv": "^16.4.5",
     "env-paths": "^3.0.0",
+    "express": "^5.1.0",
     "jimp": "^0.22.10",
     "js-yaml": "^4.1.0",
     "litellm": "^0.12.0",
     "minecraft-protocol": "^1.58.0",
     "minimist": "^1.2.8",
+    "node-pty": "^0.10.1",
+    "openai": "^4.11.1",
     "pino": "^9.3.2",
     "pino-pretty": "^11.2.2",
-    "rcon-client": "^4.2.5",
-    "sql.js": "^1.13.0",
-    "xml2js": "^0.6.2",
     "prettier": "^3.2.5",
-    "openai": "^4.11.1",
-    "node-pty": "^0.10.1"
+    "rcon-client": "^4.2.5",
+    "socket.io": "^4.8.1",
+    "sql.js": "^1.13.0",
+    "xml2js": "^0.6.2"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Cyrah Web Interface</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #log { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
+  </style>
+</head>
+<body>
+  <h1>Cyrah Web Interface</h1>
+  <div id="log"></div>
+  <input type="text" id="input" placeholder="Type a message" style="width:80%" />
+  <button id="send">Send</button>
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const socket = io();
+    const log = document.getElementById('log');
+    document.getElementById('send').onclick = () => {
+      const msg = document.getElementById('input').value;
+      if (!msg) return;
+      log.textContent += '\nYou: ' + msg;
+      socket.emit('message', msg);
+      document.getElementById('input').value = '';
+    };
+    socket.on('response', (res) => {
+      log.textContent += `\n${res.role}: ${res.content}`;
+      log.scrollTop = log.scrollHeight;
+    });
+  </script>
+</body>
+</html>

--- a/src/bin/cyrah.ts
+++ b/src/bin/cyrah.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import dotenv from 'dotenv';
 import readline from 'readline';
+import minimist from 'minimist';
 import { executeLaunchUITool } from '../tools/SystemIntegrationTool.js';
 import { main } from '../main.js';
 
@@ -9,26 +10,77 @@ dotenv.config();
 async function showMenu(): Promise<void> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
-  console.log('Cyrah Menu');
-  console.log('1) Launch UI');
-  console.log('2) Start CLI Interpreter');
-  console.log('3) Exit');
+  const ask = (query: string) => new Promise<string>((res) => rl.question(query, res));
 
-  return new Promise((resolve) => {
-    rl.question('Choose an option: ', async (answer) => {
+  while (true) {
+    console.log('Cyrah Menu');
+    console.log('1) Launch UI');
+    console.log('2) Start CLI Interpreter');
+    console.log('3) Set Environment Variables');
+    console.log('4) Exit');
+
+    const choice = (await ask('Choose an option: ')).trim();
+
+    if (choice === '1') {
+      const msg = await executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
+      console.log(msg);
+    } else if (choice === '2') {
       rl.close();
-      const choice = answer.trim();
-      if (choice === '1') {
-        const msg = await executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
-        console.log(msg);
-      } else if (choice === '2') {
-        await main();
+      await main();
+      return;
+    } else if (choice === '3') {
+      while (true) {
+        const pair = (await ask('Enter KEY=VALUE (blank to finish): ')).trim();
+        if (!pair) break;
+        const [key, ...rest] = pair.split('=');
+        if (key && rest.length > 0) {
+          process.env[key] = rest.join('=');
+        }
       }
-      resolve();
-    });
-  });
+    } else if (choice === '4') {
+      rl.close();
+      return;
+    }
+  }
 }
 
-showMenu().catch(err => {
+async function run(): Promise<void> {
+  const argv = minimist(process.argv.slice(2), {
+    string: ['env'],
+    boolean: ['menu', 'help'],
+    alias: { e: 'env', h: 'help' }
+  });
+
+  if (argv.help) {
+    console.log(`Usage: cyrah [options]
+
+Options:
+  --menu, -m          Show interactive menu
+  --env,  -e KEY=VAL  Set environment variable (repeatable)
+  --help, -h          Show this help message
+
+Any other options are forwarded to the interpreter.`);
+    return;
+  }
+
+  if (argv.env) {
+    const envs = Array.isArray(argv.env) ? argv.env : [argv.env];
+    for (const pair of envs) {
+      const [key, ...rest] = pair.split('=');
+      if (key && rest.length > 0) {
+        process.env[key] = rest.join('=');
+      }
+    }
+  }
+
+  if (argv.menu) {
+    await showMenu();
+    return;
+  }
+
+  await main();
+}
+
+run().catch(err => {
   console.error(`Error: ${err.message}`);
 });

--- a/src/bin/cyrah.ts
+++ b/src/bin/cyrah.ts
@@ -51,8 +51,8 @@ async function showMenu(): Promise<void> {
 async function run(): Promise<void> {
   const argv = minimist(process.argv.slice(2), {
     string: ['env'],
-    boolean: ['menu', 'help'],
-    alias: { e: 'env', h: 'help' }
+    boolean: ['menu', 'help', 'web'],
+    alias: { e: 'env', h: 'help', w: 'web' }
   });
 
   if (argv.help) {
@@ -60,6 +60,7 @@ async function run(): Promise<void> {
 
 Options:
   --menu, -m          Show interactive menu
+  --web,  -w          Start the web interface alongside the CLI
   --env,  -e KEY=VAL  Set environment variable (repeatable)
   --help, -h          Show this help message
 
@@ -80,6 +81,11 @@ Any other options are forwarded to the interpreter.`);
   if (argv.menu) {
     await showMenu();
     return;
+  }
+
+  if (argv.web) {
+    await import('../server.js');
+    console.log('Web interface started. Open http://localhost:3000 in your browser.');
   }
 
   await main();

--- a/src/bin/cyrah.ts
+++ b/src/bin/cyrah.ts
@@ -14,21 +14,25 @@ async function showMenu(): Promise<void> {
 
   while (true) {
     console.log('Cyrah Menu');
-    console.log('1) Launch UI');
-    console.log('2) Start CLI Interpreter');
-    console.log('3) Set Environment Variables');
-    console.log('4) Exit');
+    console.log('1) Start Web Interface');
+    console.log('2) Launch UI');
+    console.log('3) Start CLI Interpreter');
+    console.log('4) Set Environment Variables');
+    console.log('5) Exit');
 
     const choice = (await ask('Choose an option: ')).trim();
 
     if (choice === '1') {
+      await import('../server.js');
+      console.log('Web interface started. Open http://localhost:3000 in your browser.');
+    } else if (choice === '2') {
       const msg = await executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
       console.log(msg);
-    } else if (choice === '2') {
+    } else if (choice === '3') {
       rl.close();
       await main();
       return;
-    } else if (choice === '3') {
+    } else if (choice === '4') {
       while (true) {
         const pair = (await ask('Enter KEY=VALUE (blank to finish): ')).trim();
         if (!pair) break;
@@ -37,7 +41,7 @@ async function showMenu(): Promise<void> {
           process.env[key] = rest.join('=');
         }
       }
-    } else if (choice === '4') {
+    } else if (choice === '5') {
       rl.close();
       return;
     }

--- a/src/core/llm/Llm.ts
+++ b/src/core/llm/Llm.ts
@@ -1,6 +1,6 @@
 
 import { Models } from "../../const.js";
-import { Interpreter } from "@core/Interpreter.js";
+import { Interpreter } from "../Interpreter.js";
 import { logger } from "../../utils/logger.js";
 import { assert } from "console";
 import { Message, Role, MessageType, ToolCall } from "../types.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,72 @@
+import express from 'express';
+import http from 'http';
+import { Server as SocketIOServer } from 'socket.io';
+import path from 'path';
+import dotenv from 'dotenv';
+import { Interpreter } from './core/Interpreter.js';
+import { InterpreterOptions } from './core/InterpreterOptions.js';
+import { config } from './config.js';
+
+dotenv.config();
+
+function createInterpreter(): Interpreter {
+  const envBool = (value: string | undefined, fallback: boolean) => {
+    if (value === undefined) return fallback;
+    return value.toLowerCase() === 'true';
+  };
+  const envNumber = (value: string | undefined, fallback?: number) => {
+    if (value === undefined) return fallback;
+    const num = parseFloat(value);
+    return isNaN(num) ? fallback : num;
+  };
+  const envString = (value: string | undefined, fallback?: string) => {
+    return value !== undefined ? value : fallback;
+  };
+  const options: InterpreterOptions = {
+    autoRun: envBool(process.env.AUTO_RUN, true),
+    loop: envBool(process.env.LOOP, config.defaultLoop),
+    offline: envBool(process.env.OFFLINE, false),
+    verbose: envBool(process.env.VERBOSE, false),
+    debug: envBool(process.env.DEBUG, false),
+    safeMode: process.env.SAFE_MODE || config.defaultSafeMode,
+    maxOutput: envNumber(process.env.MAX_OUTPUT, config.defaultMaxOutput),
+    llmProvider: process.env.LLM_PROVIDER,
+    llmModel: process.env.LLM_MODEL,
+    llmApiKey: process.env.LLM_API_KEY || (process.env.LLM_PROVIDER === 'ollama' ? process.env.OLLAMA_API_KEY : process.env.OPENAI_API_KEY),
+    llmBaseUrl: process.env.LLM_BASE_URL || (process.env.LLM_PROVIDER === 'openai' ? process.env.OPENAI_BASE_URL : process.env.OLLAMA_BASE_URL),
+    llmTemperature: envNumber(process.env.LLM_TEMPERATURE, 0),
+    llmMaxTokens: envNumber(process.env.LLM_MAX_TOKENS, config.defaultMaxOutput),
+    conversationHistoryPath: process.env.CONVERSATION_HISTORY_PATH,
+    conversationFilename: envString(process.env.CONVERSATION_FILENAME, config.conversationFilename),
+    conversationMaxLength: envNumber(process.env.CONVERSATION_MAX_LENGTH, undefined as any),
+    skillsPath: envString(process.env.SKILLS_PATH, undefined as any),
+    importSkills: envBool(process.env.IMPORT_SKILLS, false),
+    displayMode: (process.env.DISPLAY_MODE ?? 'cli') as 'cli' | 'gui',
+  };
+
+  return new Interpreter(options);
+}
+
+const interpreter = createInterpreter();
+const app = express();
+const server = http.createServer(app);
+const io = new SocketIOServer(server);
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, '../public')));
+
+io.on('connection', (socket) => {
+  socket.on('message', async (msg: string) => {
+    try {
+      const messages = await interpreter.chat(msg);
+      socket.emit('response', messages[messages.length - 1]);
+    } catch (err: any) {
+      socket.emit('response', { role: 'error', content: err.message });
+    }
+  });
+});
+
+const PORT = parseInt(process.env.PORT || '3000', 10);
+server.listen(PORT, () => {
+  console.log(`Web interface running at http://localhost:${PORT}`);
+});

--- a/src/tools/AutomationTool.ts
+++ b/src/tools/AutomationTool.ts
@@ -2,7 +2,7 @@ import { Tool } from "../core/types.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { executeShellCommand, commandExists, shellEscape } from "@utils/command.js";
+import { executeShellCommand, commandExists, shellEscape } from "../utils/command.js";
 export const createScriptFileTool: Tool = {
   type: "function",
   function: {

--- a/src/tools/ClipboardTool.ts
+++ b/src/tools/ClipboardTool.ts
@@ -1,7 +1,7 @@
 
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 const readClipboardToolDefinition: Tool = {
   type: "function",

--- a/src/tools/CloudTool.ts
+++ b/src/tools/CloudTool.ts
@@ -1,5 +1,5 @@
 import { Tool } from "../core/types.js";
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 
 export const listCloudResourcesTool: Tool = {
   type: "function",

--- a/src/tools/CompressionTool.ts
+++ b/src/tools/CompressionTool.ts
@@ -1,7 +1,7 @@
 import { Tool } from "../core/types.js";
 import * as fs from "fs";
 import * as path from "path";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const zipCompressTool: Tool = {
   type: "function",
   function: {

--- a/src/tools/ContainerTool.ts
+++ b/src/tools/ContainerTool.ts
@@ -1,5 +1,5 @@
 import { Tool } from "../core/types.js";
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 
 async function ensureDocker(): Promise<string | null> {
   if (await commandExists("docker")) {

--- a/src/tools/LogManagementTool.ts
+++ b/src/tools/LogManagementTool.ts
@@ -1,7 +1,7 @@
 import { Tool } from "../core/types.js";
 import * as fs from "fs";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const readLogFileTool: Tool = {
   type: "function",

--- a/src/tools/NetworkConfigTool.ts
+++ b/src/tools/NetworkConfigTool.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const getNetworkConfigTool: Tool = {
   type: "function",

--- a/src/tools/NetworkDiagnosticsTool.ts
+++ b/src/tools/NetworkDiagnosticsTool.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const checkNetworkConnectivityTool: Tool = {
   type: "function",
   function: {

--- a/src/tools/PackageManagerTool.ts
+++ b/src/tools/PackageManagerTool.ts
@@ -2,7 +2,7 @@ import { Tool } from "../core/types.js";
 import * as os from "os";
 import * as path from "path"; // Added import
 import * as fs from "fs";   // Added import
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const npmInstallTool: Tool = {
   type: "function",

--- a/src/tools/ProcessManagementTool.ts
+++ b/src/tools/ProcessManagementTool.ts
@@ -1,7 +1,7 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
 import { spawn } from "child_process";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const terminateProcessTool: Tool = {
   type: "function",

--- a/src/tools/SDLCtool.ts
+++ b/src/tools/SDLCtool.ts
@@ -1,5 +1,5 @@
 import { Tool } from "../core/types.js";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const createBranchTool: Tool = {
   type: "function",

--- a/src/tools/SchedulerTool.ts
+++ b/src/tools/SchedulerTool.ts
@@ -2,7 +2,7 @@
 
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand, commandExists, shellEscape } from "@utils/command.js";
+import { executeShellCommand, commandExists, shellEscape } from "../utils/command.js";
 
 export const createScheduledTaskTool: Tool = {
   type: "function",

--- a/src/tools/SecurityTool.ts
+++ b/src/tools/SecurityTool.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { exec } from "child_process";
 import * as crypto from "crypto";
 import * as path from "path";
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 
 export const scanOpenPortsTool: Tool = {
   type: "function",

--- a/src/tools/ServiceManagementTool.ts
+++ b/src/tools/ServiceManagementTool.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const startServiceTool: Tool = {
   type: "function",
   function: {

--- a/src/tools/SystemConfigTool.ts
+++ b/src/tools/SystemConfigTool.ts
@@ -5,7 +5,7 @@ import * as yaml from "js-yaml";
 import { parseStringPromise } from "xml2js";
 import Ajv from "ajv";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const readConfigFileTool: Tool = {
   type: "function",

--- a/src/tools/SystemDiagnosticsTool.ts
+++ b/src/tools/SystemDiagnosticsTool.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const checkSystemHealthTool: Tool = {
   type: "function",
   function: {

--- a/src/tools/SystemMonitorTool.ts
+++ b/src/tools/SystemMonitorTool.ts
@@ -1,7 +1,7 @@
 
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const getDiskUsageTool: Tool = {
   type: "function",

--- a/src/tools/SystemPowerTool.ts
+++ b/src/tools/SystemPowerTool.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const rebootSystemTool: Tool = {
   type: "function",

--- a/src/tools/SystemTool.ts
+++ b/src/tools/SystemTool.ts
@@ -1,7 +1,7 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
 import { exec } from "child_process";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 
 export const systemInfoTool: Tool = {
   type: "function",

--- a/src/tools/UserManagementTool.ts
+++ b/src/tools/UserManagementTool.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../core/types.js";
 import * as os from "os";
-import { executeShellCommand } from "@utils/command.js";
+import { executeShellCommand } from "../utils/command.js";
 export const createUserTool: Tool = {
   type: "function",
   function: {

--- a/src/tools/VirtualizationTool.ts
+++ b/src/tools/VirtualizationTool.ts
@@ -1,5 +1,5 @@
 import { Tool } from "../core/types.js";
-import { executeShellCommand, commandExists } from "@utils/command.js";
+import { executeShellCommand, commandExists } from "../utils/command.js";
 
 export const listVirtualMachinesTool: Tool = {
   type: "function",


### PR DESCRIPTION
## Summary
- refactor tool imports to use relative paths instead of tsconfig aliases
- update compiled JavaScript with the new paths

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d5a0317b08323b30e92b095424489