### PR TITLE
Add web research tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This CLI agent now supports a wide range of functionalities, including:
 *   **Advanced File Analysis:** Tools like `deepSearch` (with optional depth limits), directory structure listing, and detection of file content types.
 *   **System Management Tools:** Retrieve hardware details and manage network interfaces across platforms.
 *   **Image Generation Tool:** Use the `generateImage` tool to create images from text prompts. When `OPENAI_API_KEY` is configured, the tool generates real images using OpenAI; otherwise it falls back to a placeholder image.
+*   **Web Research Tool:** The `webResearch` tool performs a search and summarizes the top results for quick reference.
 *   **Virtual Terminal Tool:** The `launchVirtualTerminal` tool uses `node-pty` to provide an interactive shell session when available and falls back to a regular shell spawn if pseudo-terminals are unsupported.
 *   **Conceptual GUI Integration:** Includes conceptual methods for display updates and input event handling, laying the groundwork for future graphical user interface implementations.
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -18,6 +18,7 @@ import { readFileTool, writeFileTool, executeReadFileTool, executeWriteFileTool,
 import { listDirectoryTool, executeListDirectoryTool } from "./tools/DirectoryTool.js";
 import { webFetchTool, executeWebFetchTool, httpRequestTool, executeHttpRequestTool } from "./tools/WebTool.js";
 import { searchTool, executeSearchTool } from "./tools/SearchTool.js";
+import { webResearchTool, executeWebResearchTool } from "./tools/WebResearchTool.js";
 import { sqlTool, executeSqlTool } from "./tools/SqlTool.js";
 import { jsonTool, executeJsonTool } from "./tools/JsonTool.js";
 import { pingTool, executePingTool, tracerouteTool, executeTracerouteTool, dnsLookupTool, executeDnsLookupTool } from "./tools/NetworkTool.js";
@@ -97,6 +98,7 @@ export function main() {
         interpreter.registerTool(webFetchTool, executeWebFetchTool);
         interpreter.registerTool(httpRequestTool, executeHttpRequestTool);
         interpreter.registerTool(searchTool, executeSearchTool);
+        interpreter.registerTool(webResearchTool, executeWebResearchTool);
         interpreter.registerTool(sqlTool, executeSqlTool);
         interpreter.registerTool(jsonTool, executeJsonTool);
         interpreter.registerTool(pingTool, executePingTool);

--- a/dist/tools/WebResearchTool.js
+++ b/dist/tools/WebResearchTool.js
@@ -1,0 +1,73 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+export const webResearchTool = {
+    type: "function",
+    function: {
+        name: "webResearch",
+        description: "Performs a web search and fetches short summaries from the top results.",
+        parameters: {
+            type: "object",
+            properties: {
+                query: {
+                    type: "string",
+                    description: "The search query.",
+                },
+                numResults: {
+                    type: "number",
+                    description: "Optional: number of results to summarize. Defaults to 3.",
+                    nullable: true,
+                },
+            },
+            required: ["query"],
+        },
+    },
+};
+export function executeWebResearchTool(args) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var _a;
+        try {
+            const q = encodeURIComponent(args.query);
+            const resultsToFetch = (_a = args.numResults) !== null && _a !== void 0 ? _a : 3;
+            const searchUrl = `https://www.google.com/search?q=${q}`;
+            const { data } = yield axios.get(searchUrl, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+            const $ = cheerio.load(data);
+            const results = [];
+            $('div.g').each((i, el) => {
+                if (results.length >= resultsToFetch)
+                    return;
+                const link = $(el).find('a').attr('href');
+                const title = $(el).find('h3').text();
+                if (link && title) {
+                    results.push({ title, link });
+                }
+            });
+            const summaries = [];
+            for (const result of results) {
+                try {
+                    const res = yield axios.get(result.link, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+                    const page = cheerio.load(res.data);
+                    const text = page('body').text().replace(/\s+/g, ' ').trim();
+                    summaries.push(`${result.title}: ${text.substring(0, 200)}... (${result.link})`);
+                }
+                catch (_b) {
+                    summaries.push(`${result.title}: Unable to fetch (${result.link})`);
+                }
+            }
+            return summaries.length > 0
+                ? `Web research results for "${args.query}":\n` + summaries.join('\n')
+                : `No web research results found for "${args.query}".`;
+        }
+        catch (error) {
+            return `Error performing web research: ${error.message}`;
+        }
+    });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { readFileTool, writeFileTool, executeReadFileTool, executeWriteFileTool,
 import { listDirectoryTool, executeListDirectoryTool } from "./tools/DirectoryTool.js";
 import { webFetchTool, executeWebFetchTool, httpRequestTool, executeHttpRequestTool } from "./tools/WebTool.js";
 import { searchTool, executeSearchTool } from "./tools/SearchTool.js";
+import { webResearchTool, executeWebResearchTool } from "./tools/WebResearchTool.js";
 import { sqlTool, executeSqlTool } from "./tools/SqlTool.js";
 import { jsonTool, executeJsonTool } from "./tools/JsonTool.js";
 import { pingTool, executePingTool, tracerouteTool, executeTracerouteTool, dnsLookupTool, executeDnsLookupTool } from "./tools/NetworkTool.js";
@@ -117,6 +118,7 @@ export async function main() {
   interpreter.registerTool(webFetchTool, executeWebFetchTool);
   interpreter.registerTool(httpRequestTool, executeHttpRequestTool);
   interpreter.registerTool(searchTool, executeSearchTool);
+  interpreter.registerTool(webResearchTool, executeWebResearchTool);
   interpreter.registerTool(sqlTool, executeSqlTool);
   interpreter.registerTool(jsonTool, executeJsonTool);
   interpreter.registerTool(pingTool, executePingTool);

--- a/src/tools/WebResearchTool.ts
+++ b/src/tools/WebResearchTool.ts
@@ -1,0 +1,63 @@
+import { Tool } from "../core/types.js";
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+
+export const webResearchTool: Tool = {
+  type: "function",
+  function: {
+    name: "webResearch",
+    description: "Performs a web search and fetches short summaries from the top results.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The search query.",
+        },
+        numResults: {
+          type: "number",
+          description: "Optional: number of results to summarize. Defaults to 3.",
+          nullable: true,
+        },
+      },
+      required: ["query"],
+    },
+  },
+};
+
+export async function executeWebResearchTool(args: { query: string; numResults?: number }): Promise<string> {
+  try {
+    const q = encodeURIComponent(args.query);
+    const resultsToFetch = args.numResults ?? 3;
+    const searchUrl = `https://www.google.com/search?q=${q}`;
+    const { data } = await axios.get(searchUrl, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+    const $ = cheerio.load(data);
+    const results: { title: string; link: string }[] = [];
+    $('div.g').each((i, el) => {
+      if (results.length >= resultsToFetch) return;
+      const link = $(el).find('a').attr('href');
+      const title = $(el).find('h3').text();
+      if (link && title) {
+        results.push({ title, link });
+      }
+    });
+
+    const summaries: string[] = [];
+    for (const result of results) {
+      try {
+        const res = await axios.get(result.link, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+        const page = cheerio.load(res.data);
+        const text = page('body').text().replace(/\s+/g, ' ').trim();
+        summaries.push(`${result.title}: ${text.substring(0, 200)}... (${result.link})`);
+      } catch {
+        summaries.push(`${result.title}: Unable to fetch (${result.link})`);
+      }
+    }
+
+    return summaries.length > 0
+      ? `Web research results for "${args.query}":\n` + summaries.join('\n')
+      : `No web research results found for "${args.query}".`;
+  } catch (error: any) {
+    return `Error performing web research: ${error.message}`;
+  }
+}

--- a/tests/tools/WebResearchTool.test.ts
+++ b/tests/tools/WebResearchTool.test.ts
@@ -1,0 +1,22 @@
+import { jest } from '@jest/globals';
+import { executeWebResearchTool } from '@/tools/WebResearchTool';
+import axios from 'axios';
+
+describe('WebResearchTool', () => {
+  const originalGet = axios.get;
+
+  afterEach(() => {
+    (axios as any).get = originalGet;
+  });
+
+  it('returns summarized search results', async () => {
+    const mockGet = jest.fn()
+      .mockResolvedValueOnce({ data: "<div class='g'><a href='http://example.com'><h3>Example</h3></a></div>" })
+      .mockResolvedValueOnce({ data: '<body>This is a test page with interesting information.</body>' });
+    (axios as any).get = mockGet;
+
+    const result = await executeWebResearchTool({ query: 'test', numResults: 1 });
+    expect(result).toContain('Example: This is a test page');
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add new webResearch tool for quick search summaries
- register new tool in the interpreter
- document the tool in README

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d7819cc98832394ed3dfff628b5c7