### PR TITLE
Improve CLI menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,18 @@ You can also launch a simple web interface:
 npm run start-web
 ```
 Then open http://localhost:3000 in your browser to chat. The interactive menu
-now includes an option to start this server as well, or you can launch it
-alongside the CLI with the `--web` flag.
+includes options to start just the web server or to start it alongside the CLI.
+You can also launch both together with the `--web` flag or choose "Start CLI and
+Web Interface" from the menu.
 
-This command now starts the CLI interpreter immediately. If you prefer the
-previous interactive menu, run `npx cyrah --menu`. Use `npx cyrah --web` to
-start the web interface alongside the CLI.
+Running `npx cyrah` now opens the interactive menu by default. Pass
+`--no-menu` to start the CLI interpreter immediately. Use `npx cyrah --web`
+to launch the web interface alongside the CLI.
 
 You can pass interpreter options directly on the command line or via
-environment variables. Use `--env KEY=VALUE` to set an environment variable for
+environment variables. Use `--env KEY=VALUE` to set a variable for
 the current run, or choose **Set Environment Variables** in the interactive
-menu to enter them interactively. A `--help` flag shows the available options.
+menu to review, update, or unset variables. A `--help` flag shows the available options.
 
 ## Configuration via Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ to launch the web interface alongside the CLI.
 You can pass interpreter options directly on the command line or via
 environment variables. Use `--env KEY=VALUE` to set a variable for
 the current run, or choose **Set Environment Variables** in the interactive
-menu to review, update, or unset variables. A `--help` flag shows the available options.
+menu to review, update, or unset variables. Environment values can also be
+loaded from or saved to a file using `--env-file path` or the **Load Env File**
+and **Save Env File** options in the menu. A `--help` flag shows the available options.
 
 ## Configuration via Environment Variables
 

--- a/dist/bin/cyrah.js
+++ b/dist/bin/cyrah.js
@@ -14,43 +14,75 @@ import minimist from 'minimist';
 import { executeLaunchUITool } from '../tools/SystemIntegrationTool.js';
 import { main } from '../main.js';
 dotenv.config();
+const RELEVANT_ENV_VARS = [
+    'LLM_PROVIDER', 'LLM_MODEL', 'LLM_API_KEY', 'LLM_BASE_URL',
+    'OPENAI_API_KEY', 'OLLAMA_API_KEY',
+    'AUTO_RUN', 'LOOP', 'OFFLINE', 'VERBOSE', 'DEBUG',
+    'SAFE_MODE', 'MAX_OUTPUT', 'DISPLAY_MODE', 'UI_NAME'
+];
+function manageEnvVariables(ask) {
+    return __awaiter(this, void 0, void 0, function* () {
+        console.log('\nCurrent environment variables:');
+        for (const key of RELEVANT_ENV_VARS) {
+            if (process.env[key]) {
+                console.log(`${key}=${process.env[key]}`);
+            }
+        }
+        while (true) {
+            const pair = (yield ask('Enter KEY=VALUE to set, KEY to unset (blank to finish): ')).trim();
+            if (!pair)
+                break;
+            if (!pair.includes('=')) {
+                delete process.env[pair];
+                console.log(`Unset ${pair}`);
+            }
+            else {
+                const [key, ...rest] = pair.split('=');
+                if (key && rest.length > 0) {
+                    process.env[key] = rest.join('=');
+                    console.log(`Set ${key}=${process.env[key]}`);
+                }
+            }
+        }
+    });
+}
 function showMenu() {
     return __awaiter(this, void 0, void 0, function* () {
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
         const ask = (query) => new Promise((res) => rl.question(query, res));
         while (true) {
             console.log('Cyrah Menu');
-            console.log('1) Start Web Interface');
-            console.log('2) Launch UI');
-            console.log('3) Start CLI Interpreter');
-            console.log('4) Set Environment Variables');
-            console.log('5) Exit');
+            console.log('1) Start CLI Interpreter');
+            console.log('2) Start Web Interface');
+            console.log('3) Start CLI and Web Interface');
+            console.log('4) Launch UI');
+            console.log('5) Set Environment Variables');
+            console.log('6) Exit');
             const choice = (yield ask('Choose an option: ')).trim();
             if (choice === '1') {
+                rl.close();
+                yield main();
+                return;
+            }
+            else if (choice === '2') {
                 yield import('../server.js');
                 console.log('Web interface started. Open http://localhost:3000 in your browser.');
             }
-            else if (choice === '2') {
-                const msg = yield executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
-                console.log(msg);
-            }
             else if (choice === '3') {
+                yield import('../server.js');
+                console.log('Web interface started. Open http://localhost:3000 in your browser.');
                 rl.close();
                 yield main();
                 return;
             }
             else if (choice === '4') {
-                while (true) {
-                    const pair = (yield ask('Enter KEY=VALUE (blank to finish): ')).trim();
-                    if (!pair)
-                        break;
-                    const [key, ...rest] = pair.split('=');
-                    if (key && rest.length > 0) {
-                        process.env[key] = rest.join('=');
-                    }
-                }
+                const msg = yield executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
+                console.log(msg);
             }
             else if (choice === '5') {
+                yield manageEnvVariables(ask);
+            }
+            else if (choice === '6') {
                 rl.close();
                 return;
             }
@@ -61,14 +93,15 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         const argv = minimist(process.argv.slice(2), {
             string: ['env'],
-            boolean: ['menu', 'help', 'web'],
-            alias: { e: 'env', h: 'help', w: 'web' }
+            boolean: ['menu', 'help', 'web', 'no-menu'],
+            alias: { e: 'env', h: 'help', w: 'web', n: 'no-menu' }
         });
         if (argv.help) {
             console.log(`Usage: cyrah [options]
 
 Options:
   --menu, -m          Show interactive menu
+  --no-menu, -n       Skip the menu and run the CLI directly
   --web,  -w          Start the web interface alongside the CLI
   --env,  -e KEY=VAL  Set environment variable (repeatable)
   --help, -h          Show this help message
@@ -85,7 +118,8 @@ Any other options are forwarded to the interpreter.`);
                 }
             }
         }
-        if (argv.menu) {
+        const noArgs = process.argv.slice(2).length === 0;
+        if (argv.menu || (noArgs && !argv['no-menu'])) {
             yield showMenu();
             return;
         }

--- a/dist/bin/cyrah.js
+++ b/dist/bin/cyrah.js
@@ -10,7 +10,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import dotenv from 'dotenv';
 import readline from 'readline';
+import fs from 'fs';
 import minimist from 'minimist';
+import { parse } from 'dotenv';
 import { executeLaunchUITool } from '../tools/SystemIntegrationTool.js';
 import { main } from '../main.js';
 dotenv.config();
@@ -20,6 +22,24 @@ const RELEVANT_ENV_VARS = [
     'AUTO_RUN', 'LOOP', 'OFFLINE', 'VERBOSE', 'DEBUG',
     'SAFE_MODE', 'MAX_OUTPUT', 'DISPLAY_MODE', 'UI_NAME'
 ];
+function loadEnvFile(filePath) {
+    if (!fs.existsSync(filePath))
+        return;
+    const data = fs.readFileSync(filePath, 'utf-8');
+    const parsed = parse(data);
+    for (const [k, v] of Object.entries(parsed)) {
+        process.env[k] = v;
+    }
+}
+function saveEnvFile(filePath) {
+    const lines = [];
+    for (const key of RELEVANT_ENV_VARS) {
+        if (process.env[key]) {
+            lines.push(`${key}=${process.env[key]}`);
+        }
+    }
+    fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
+}
 function manageEnvVariables(ask) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log('\nCurrent environment variables:');
@@ -29,15 +49,25 @@ function manageEnvVariables(ask) {
             }
         }
         while (true) {
-            const pair = (yield ask('Enter KEY=VALUE to set, KEY to unset (blank to finish): ')).trim();
-            if (!pair)
+            const input = (yield ask('Enter KEY=VALUE, KEY to unset, :load FILE, :save FILE (blank to finish): ')).trim();
+            if (!input)
                 break;
-            if (!pair.includes('=')) {
-                delete process.env[pair];
-                console.log(`Unset ${pair}`);
+            if (input.startsWith(':load ')) {
+                loadEnvFile(input.slice(6));
+                console.log('Loaded variables from file.');
+                continue;
+            }
+            if (input.startsWith(':save ')) {
+                saveEnvFile(input.slice(6));
+                console.log('Saved variables to file.');
+                continue;
+            }
+            if (!input.includes('=')) {
+                delete process.env[input];
+                console.log(`Unset ${input}`);
             }
             else {
-                const [key, ...rest] = pair.split('=');
+                const [key, ...rest] = input.split('=');
                 if (key && rest.length > 0) {
                     process.env[key] = rest.join('=');
                     console.log(`Set ${key}=${process.env[key]}`);
@@ -57,7 +87,9 @@ function showMenu() {
             console.log('3) Start CLI and Web Interface');
             console.log('4) Launch UI');
             console.log('5) Set Environment Variables');
-            console.log('6) Exit');
+            console.log('6) Load Env File');
+            console.log('7) Save Env File');
+            console.log('8) Exit');
             const choice = (yield ask('Choose an option: ')).trim();
             if (choice === '1') {
                 rl.close();
@@ -83,6 +115,14 @@ function showMenu() {
                 yield manageEnvVariables(ask);
             }
             else if (choice === '6') {
+                const file = yield ask('Path to env file: ');
+                loadEnvFile(file.trim());
+            }
+            else if (choice === '7') {
+                const file = yield ask('Path to save env file: ');
+                saveEnvFile(file.trim());
+            }
+            else if (choice === '8') {
                 rl.close();
                 return;
             }
@@ -92,9 +132,9 @@ function showMenu() {
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         const argv = minimist(process.argv.slice(2), {
-            string: ['env'],
+            string: ['env', 'env-file'],
             boolean: ['menu', 'help', 'web', 'no-menu'],
-            alias: { e: 'env', h: 'help', w: 'web', n: 'no-menu' }
+            alias: { e: 'env', F: 'env-file', h: 'help', w: 'web', n: 'no-menu' }
         });
         if (argv.help) {
             console.log(`Usage: cyrah [options]
@@ -104,10 +144,14 @@ Options:
   --no-menu, -n       Skip the menu and run the CLI directly
   --web,  -w          Start the web interface alongside the CLI
   --env,  -e KEY=VAL  Set environment variable (repeatable)
+  --env-file, -F FILE Load environment variables from file
   --help, -h          Show this help message
 
 Any other options are forwarded to the interpreter.`);
             return;
+        }
+        if (argv['env-file']) {
+            loadEnvFile(argv['env-file']);
         }
         if (argv.env) {
             const envs = Array.isArray(argv.env) ? argv.env : [argv.env];

--- a/src/bin/cyrah.ts
+++ b/src/bin/cyrah.ts
@@ -7,6 +7,37 @@ import { main } from '../main.js';
 
 dotenv.config();
 
+const RELEVANT_ENV_VARS = [
+  'LLM_PROVIDER', 'LLM_MODEL', 'LLM_API_KEY', 'LLM_BASE_URL',
+  'OPENAI_API_KEY', 'OLLAMA_API_KEY',
+  'AUTO_RUN', 'LOOP', 'OFFLINE', 'VERBOSE', 'DEBUG',
+  'SAFE_MODE', 'MAX_OUTPUT', 'DISPLAY_MODE', 'UI_NAME'
+];
+
+async function manageEnvVariables(ask: (q: string) => Promise<string>): Promise<void> {
+  console.log('\nCurrent environment variables:');
+  for (const key of RELEVANT_ENV_VARS) {
+    if (process.env[key]) {
+      console.log(`${key}=${process.env[key]}`);
+    }
+  }
+
+  while (true) {
+    const pair = (await ask('Enter KEY=VALUE to set, KEY to unset (blank to finish): ')).trim();
+    if (!pair) break;
+    if (!pair.includes('=')) {
+      delete process.env[pair];
+      console.log(`Unset ${pair}`);
+    } else {
+      const [key, ...rest] = pair.split('=');
+      if (key && rest.length > 0) {
+        process.env[key] = rest.join('=');
+        console.log(`Set ${key}=${process.env[key]}`);
+      }
+    }
+  }
+}
+
 async function showMenu(): Promise<void> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
@@ -14,34 +45,34 @@ async function showMenu(): Promise<void> {
 
   while (true) {
     console.log('Cyrah Menu');
-    console.log('1) Start Web Interface');
-    console.log('2) Launch UI');
-    console.log('3) Start CLI Interpreter');
-    console.log('4) Set Environment Variables');
-    console.log('5) Exit');
+    console.log('1) Start CLI Interpreter');
+    console.log('2) Start Web Interface');
+    console.log('3) Start CLI and Web Interface');
+    console.log('4) Launch UI');
+    console.log('5) Set Environment Variables');
+    console.log('6) Exit');
 
     const choice = (await ask('Choose an option: ')).trim();
 
     if (choice === '1') {
+      rl.close();
+      await main();
+      return;
+    } else if (choice === '2') {
       await import('../server.js');
       console.log('Web interface started. Open http://localhost:3000 in your browser.');
-    } else if (choice === '2') {
-      const msg = await executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
-      console.log(msg);
     } else if (choice === '3') {
+      await import('../server.js');
+      console.log('Web interface started. Open http://localhost:3000 in your browser.');
       rl.close();
       await main();
       return;
     } else if (choice === '4') {
-      while (true) {
-        const pair = (await ask('Enter KEY=VALUE (blank to finish): ')).trim();
-        if (!pair) break;
-        const [key, ...rest] = pair.split('=');
-        if (key && rest.length > 0) {
-          process.env[key] = rest.join('=');
-        }
-      }
+      const msg = await executeLaunchUITool({ uiName: process.env.UI_NAME || 'cyrah' });
+      console.log(msg);
     } else if (choice === '5') {
+      await manageEnvVariables(ask);
+    } else if (choice === '6') {
       rl.close();
       return;
     }
@@ -51,8 +82,8 @@ async function showMenu(): Promise<void> {
 async function run(): Promise<void> {
   const argv = minimist(process.argv.slice(2), {
     string: ['env'],
-    boolean: ['menu', 'help', 'web'],
-    alias: { e: 'env', h: 'help', w: 'web' }
+    boolean: ['menu', 'help', 'web', 'no-menu'],
+    alias: { e: 'env', h: 'help', w: 'web', n: 'no-menu' }
   });
 
   if (argv.help) {
@@ -60,6 +91,7 @@ async function run(): Promise<void> {
 
 Options:
   --menu, -m          Show interactive menu
+  --no-menu, -n       Skip the menu and run the CLI directly
   --web,  -w          Start the web interface alongside the CLI
   --env,  -e KEY=VAL  Set environment variable (repeatable)
   --help, -h          Show this help message
@@ -78,7 +110,8 @@ Any other options are forwarded to the interpreter.`);
     }
   }
 
-  if (argv.menu) {
+  const noArgs = process.argv.slice(2).length === 0;
+  if (argv.menu || (noArgs && !argv['no-menu'])) {
     await showMenu();
     return;
   }

--- a/src/bin/cyrah.ts
+++ b/src/bin/cyrah.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import dotenv from 'dotenv';
 import readline from 'readline';
+import fs from 'fs';
 import minimist from 'minimist';
+import { parse } from 'dotenv';
 import { executeLaunchUITool } from '../tools/SystemIntegrationTool.js';
 import { main } from '../main.js';
 
@@ -14,6 +16,25 @@ const RELEVANT_ENV_VARS = [
   'SAFE_MODE', 'MAX_OUTPUT', 'DISPLAY_MODE', 'UI_NAME'
 ];
 
+function loadEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) return;
+  const data = fs.readFileSync(filePath, 'utf-8');
+  const parsed = parse(data);
+  for (const [k, v] of Object.entries(parsed)) {
+    process.env[k] = v;
+  }
+}
+
+function saveEnvFile(filePath: string): void {
+  const lines: string[] = [];
+  for (const key of RELEVANT_ENV_VARS) {
+    if (process.env[key]) {
+      lines.push(`${key}=${process.env[key]}`);
+    }
+  }
+  fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
+}
+
 async function manageEnvVariables(ask: (q: string) => Promise<string>): Promise<void> {
   console.log('\nCurrent environment variables:');
   for (const key of RELEVANT_ENV_VARS) {
@@ -23,13 +44,23 @@ async function manageEnvVariables(ask: (q: string) => Promise<string>): Promise<
   }
 
   while (true) {
-    const pair = (await ask('Enter KEY=VALUE to set, KEY to unset (blank to finish): ')).trim();
-    if (!pair) break;
-    if (!pair.includes('=')) {
-      delete process.env[pair];
-      console.log(`Unset ${pair}`);
+    const input = (await ask('Enter KEY=VALUE, KEY to unset, :load FILE, :save FILE (blank to finish): ')).trim();
+    if (!input) break;
+    if (input.startsWith(':load ')) {
+      loadEnvFile(input.slice(6));
+      console.log('Loaded variables from file.');
+      continue;
+    }
+    if (input.startsWith(':save ')) {
+      saveEnvFile(input.slice(6));
+      console.log('Saved variables to file.');
+      continue;
+    }
+    if (!input.includes('=')) {
+      delete process.env[input];
+      console.log(`Unset ${input}`);
     } else {
-      const [key, ...rest] = pair.split('=');
+      const [key, ...rest] = input.split('=');
       if (key && rest.length > 0) {
         process.env[key] = rest.join('=');
         console.log(`Set ${key}=${process.env[key]}`);
@@ -50,7 +81,9 @@ async function showMenu(): Promise<void> {
     console.log('3) Start CLI and Web Interface');
     console.log('4) Launch UI');
     console.log('5) Set Environment Variables');
-    console.log('6) Exit');
+    console.log('6) Load Env File');
+    console.log('7) Save Env File');
+    console.log('8) Exit');
 
     const choice = (await ask('Choose an option: ')).trim();
 
@@ -73,6 +106,12 @@ async function showMenu(): Promise<void> {
     } else if (choice === '5') {
       await manageEnvVariables(ask);
     } else if (choice === '6') {
+      const file = await ask('Path to env file: ');
+      loadEnvFile(file.trim());
+    } else if (choice === '7') {
+      const file = await ask('Path to save env file: ');
+      saveEnvFile(file.trim());
+    } else if (choice === '8') {
       rl.close();
       return;
     }
@@ -81,9 +120,9 @@ async function showMenu(): Promise<void> {
 
 async function run(): Promise<void> {
   const argv = minimist(process.argv.slice(2), {
-    string: ['env'],
+    string: ['env', 'env-file'],
     boolean: ['menu', 'help', 'web', 'no-menu'],
-    alias: { e: 'env', h: 'help', w: 'web', n: 'no-menu' }
+    alias: { e: 'env', F: 'env-file', h: 'help', w: 'web', n: 'no-menu' }
   });
 
   if (argv.help) {
@@ -94,10 +133,15 @@ Options:
   --no-menu, -n       Skip the menu and run the CLI directly
   --web,  -w          Start the web interface alongside the CLI
   --env,  -e KEY=VAL  Set environment variable (repeatable)
+  --env-file, -F FILE Load environment variables from file
   --help, -h          Show this help message
 
 Any other options are forwarded to the interpreter.`);
     return;
+  }
+
+  if (argv['env-file']) {
+    loadEnvFile(argv['env-file']);
   }
 
   if (argv.env) {


### PR DESCRIPTION
## Summary
- update CLI interactive menu to show by default
- add `--no-menu` flag to skip it and start CLI directly
- document new behavior in README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687d8be4f1b083239150a01c119824fe